### PR TITLE
feat: translate existing srt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ subtra /path/to/video.mkv
 ```
 
 This creates `/path/to/video.srt` with Portuguese subtitles.
+Translate an existing SRT file:
+
+```bash
+subtra /path/to/subs.srt
+```
+
+This writes `/path/to/subs_pt_br.srt` without touching the original file.
 Progress is logged as a percentage, each batch of 50 lines (configurable with `--batch-size`) reports an estimated
 time remaining in minutes and seconds, and the tool saves a partial translation to
 `/path/to/video_partial_translation_pt_br`. If interrupted, re-running the same

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -22,7 +22,7 @@ struct Cli {
     #[arg(long, default_value_t = DEFAULT_BATCH_SIZE)]
     batch_size: usize,
 
-    /// Path to the video file we want to process.
+    /// Path to the video or SRT file we want to process.
     input: PathBuf,
 }
 
@@ -41,9 +41,7 @@ fn main() -> Result<()> {
             .add_directive("subtra_core=info".parse().unwrap())
             .add_directive("warn".parse().unwrap())
     };
-    tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .init();
+    tracing_subscriber::fmt().with_env_filter(filter).init();
     if cli.onlyextract {
         extract_english_subtitles(&cli.input)?;
     } else {

--- a/tasks/0010-srt-input.md
+++ b/tasks/0010-srt-input.md
@@ -1,0 +1,15 @@
+# Task number
+0010
+# What client asked
+When an srt file is passed as parameter instead of a video file, it should translate it, the same way it would translate the one that was extracted from the video file. The file name should be name_of_original_pt_br.srt
+# Technical solution
+- Detect `.srt` inputs and skip subtitle extraction.
+- Translate the provided subtitles directly and write `<stem>_pt_br.srt`.
+- Added test with a mock translator to cover SRT inputs.
+- Updated CLI docs and README to document SRT support.
+# What changed
+- `process_file` now handles SRT files and names output with `_pt_br`.
+- CLI help mentions video or SRT inputs.
+- README explains translating SRT files.
+- Added regression test and task record.
+# Notes


### PR DESCRIPTION
## Summary
- translate standalone SRT files and write `<stem>_pt_br.srt`
- note SRT support in CLI and README
- test translating SRT without video extraction

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b35b9ba5c88329a0f7e70f7d3726f6