### PR TITLE
feat: keep translation lines aligned

### DIFF
--- a/tasks/0011-index-json.md
+++ b/tasks/0011-index-json.md
@@ -1,0 +1,14 @@
+# Task number
+0011
+# What client asked
+Fix misalignment of translated lines by including SRT index in prompts and returning JSON with indexes.
+# Technical solution
+Introduce an `IndexedLine` struct and update the translation pipeline to send lines with their indices and parse OpenAI responses containing `translatedLines` objects keyed by index.
+# What changed
+- Added `IndexedLine` struct and updated `Translator` trait.
+- Modified OpenAI translator to request/parse indexed JSON and include an example in the prompt.
+- Updated processing logic to map translations by index.
+- Adjusted tests and mock translator implementation.
+# Notes
+None
+


### PR DESCRIPTION
## Summary
- track subtitle indices with new `IndexedLine` type
- prompt OpenAI with indexes and parse `translatedLines` JSON
- map translated lines back to SRT entries via index

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b3605e2c8c832981d403190613f6d1