### PR TITLE
feat: externalize prompts with language token

### DIFF
--- a/crates/core/src/translate/prompts/glossary_system.prompt
+++ b/crates/core/src/translate/prompts/glossary_system.prompt
@@ -1,0 +1,1 @@
+Summarize the video and provide a glossary to avoid mistranslations when translating to $LANGUAGE.

--- a/crates/core/src/translate/prompts/translate_system.prompt
+++ b/crates/core/src/translate/prompts/translate_system.prompt
@@ -1,0 +1,1 @@
+You translate English subtitles to $LANGUAGE and return JSON with translatedLines.

--- a/crates/core/src/translate/prompts/translate_user.prompt
+++ b/crates/core/src/translate/prompts/translate_user.prompt
@@ -1,0 +1,15 @@
+Summary:
+$SUMMARY
+
+Previous lines:
+$PREVIOUS_LINES
+
+Translate the following lines to $TARGET_LOCALE. Each line starts with its SRT index. Return a JSON object with key 'translatedLines' as an array of objects with 'index' and 'translation'.
+Example input:
+$EXAMPLE_IN
+
+Example output:
+$EXAMPLE_OUT
+
+Lines:
+$LINES

--- a/tasks/0012-isolate-prompts.md
+++ b/tasks/0012-isolate-prompts.md
@@ -1,0 +1,12 @@
+# Task number
+0012
+# What client asked
+Isolate prompts into files and allow tokens like $LANGUAGE with default "Brazilian Portuguese".
+# Technical solution
+- Added prompt templates under `crates/core/src/translate/prompts`.
+- Replaced inline strings with templates loaded using `include_str!` and token substitution.
+- Introduced `$LANGUAGE` token with a default of "Brazilian Portuguese".
+# What changed
+- Prompt files added for translation system, translation user, and glossary system.
+- OpenAI translator now loads templates and replaces tokens.
+# Notes


### PR DESCRIPTION
## Summary
- move translation and glossary prompts into dedicated files
- support $LANGUAGE token with default Brazilian Portuguese
- build prompts for translation batches from file templates

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b3706345c883299925a8e4c28f497f