### PR TITLE
Parallelize subtitle translation with async batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,12 +638,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -651,6 +667,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -715,9 +742,11 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1862,6 +1891,7 @@ dependencies = [
  "anyhow",
  "clap",
  "subtra-core",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1871,11 +1901,14 @@ name = "subtra-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
+ "futures",
  "httpmock",
  "reqwest",
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,28 +638,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -667,17 +651,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -742,13 +715,9 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1902,7 +1871,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "futures",
  "httpmock",
  "reqwest",
  "serde",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -9,3 +9,4 @@ clap = { version = "4", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 subtra-core = { path = "../core" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -28,7 +28,8 @@ struct Cli {
 
 /// Application entry point which parses CLI args and performs actions.
 /// This function should initialize logging and delegate to the core library.
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let cli = Cli::parse();
     let filter = if cli.debug {
         EnvFilter::default()
@@ -46,7 +47,7 @@ fn main() -> Result<()> {
         extract_english_subtitles(&cli.input)?;
     } else {
         let translator = OpenAiTranslator::new()?;
-        process_file(&cli.input, &translator, cli.batch_size)?;
+        process_file(&cli.input, translator, cli.batch_size).await?;
     }
     Ok(())
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,8 +8,11 @@ anyhow = "1"
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+async-trait = "0.1"
+futures = "0.3"
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 httpmock = "0.6"
 tempfile = "3"
+tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,10 +9,9 @@ tracing = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-trait = "0.1"
-futures = "0.3"
+tokio = { version = "1", features = ["rt", "macros"] }
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 
 [dev-dependencies]
 httpmock = "0.6"
 tempfile = "3"
-tokio = { version = "1", features = ["rt", "macros"] }

--- a/tasks/0015-async-translation.md
+++ b/tasks/0015-async-translation.md
@@ -1,0 +1,12 @@
+# Task number
+0015
+# What client asked
+Make the translation async and parallelize batches while keeping output order.
+# Technical solution
+Converted translation trait and OpenAI implementation to async using `async-trait` and `reqwest` async client. Reworked `process_file` to spawn all batch translations concurrently with `FuturesUnordered`, collecting results in order using a `BTreeMap`. Updated CLI to run inside a Tokio runtime.
+# What changed
+- Added async translation infrastructure and parallel batch processing.
+- Switched to async reqwest client and futures utilities.
+- CLI now uses Tokio runtime and awaits `process_file`.
+# Notes
+None.

--- a/tasks/0016-central-consumer.md
+++ b/tasks/0016-central-consumer.md
@@ -1,0 +1,15 @@
+# 0016-central-consumer
+
+# What client asked
+Fix async translation so all lines are processed and logging/ETA are correct. Centralize translation writes.
+
+# Technical solution
+Spawn translation producers that send results over an mpsc channel to a single consumer which updates blocks, tracks progress and ETA, and ensures every line is translated.
+
+# What changed
+- Used an mpsc channel with a central consumer to apply translations in order
+- Simplified dependencies and added tokio to core crate
+- Added a check to ensure 100% of lines are translated before writing output
+
+# Notes
+

--- a/tasks/0017-retry-failed-lines.md
+++ b/tasks/0017-retry-failed-lines.md
@@ -1,0 +1,10 @@
+# Task number
+0017
+# What client asked
+Retry failed translation batches instead of erroring.
+# Technical solution
+Add a batch map and respawn failed batches until all lines are translated.
+# What changed
+- Retry mechanism in translation pipeline
+- Added unit test for retrying failed batch
+# Notes

--- a/tasks/0018-requeue-untranslated.md
+++ b/tasks/0018-requeue-untranslated.md
@@ -1,0 +1,16 @@
+# Task number
+0018-requeue-untranslated
+
+# What client asked
+If some lines were not translated, try again and never error.
+
+# Technical solution
+Detect when a translation batch returns lines identical to the input and requeue that batch until it changes. Remove the final untranslated-lines check.
+
+# What changed
+- Requeue batches whose translation is unchanged
+- Drop post-loop untranslated-lines error
+- Add a regression test for unchanged translations
+
+# Notes
+Retries run until a different translation is returned.

--- a/tasks/0019-limit-concurrency.md
+++ b/tasks/0019-limit-concurrency.md
@@ -1,0 +1,9 @@
+# 0019-limit-concurrency
+# What client asked
+Limit OpenAI requests to 4 threads at a time to avoid hitting rate limits.
+# Technical solution
+Add a semaphore in the translation orchestrator to cap concurrent batches at four and test that limit.
+# What changed
+- Introduced MAX_CONCURRENT_BATCHES constant and semaphore to throttle batch spawning
+- Added regression test verifying at most four concurrent batches run
+# Notes


### PR DESCRIPTION
## Summary
- Convert translation trait and OpenAI client to async for concurrent requests
- Run subtitle translation batches in parallel while preserving SRT order
- Use a Tokio-powered CLI to drive the async pipeline

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b37f5d67e48329a5733e099c075ff7